### PR TITLE
Filter out routes exceeding one hour

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -34,6 +34,17 @@ interface RouteResult {
   transitDetails?: TransitDetails;
 }
 
+function parseDurationToMinutes(duration: string): number {
+  const hourMatch = duration.match(/(\d+)h/);
+  const minuteMatch = duration.match(/(\d+)m/);
+  const hours = hourMatch ? parseInt(hourMatch[1], 10) : 0;
+  const minutes = minuteMatch ? parseInt(minuteMatch[1], 10) : 0;
+  if (!hourMatch && !minuteMatch) {
+    return 0;
+  }
+  return hours * 60 + minutes;
+}
+
 const DEFAULT_DESTINATIONS = [
   {
     name: 'Foothills',
@@ -83,7 +94,10 @@ export default function Home() {
       }
 
       const data = await response.json();
-      setRoutes(data.routes || []);
+      const filteredRoutes = (data.routes || []).filter(
+        (route: RouteResult) => parseDurationToMinutes(route.duration) <= 60,
+      );
+      setRoutes(filteredRoutes);
     } catch (error) {
       console.error('Error calculating routes:', error);
       setRoutes([]);


### PR DESCRIPTION
## Summary
- add helper to parse duration strings into minutes
- ignore route results with travel times over 60 minutes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint errors in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_689ed41faf3c832a941ee35b1a9958d7