### PR TITLE
Fix lint errors and clean up types

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import { UserObject } from '../types/user';
 
 interface HeaderProps {
@@ -40,7 +41,13 @@ export function Header({ currentUser }: HeaderProps) {
             {currentUser.picture && (
               <div className="avatar">
                 <div className="w-10 h-10 rounded-full ring-2 ring-success ring-offset-base-100 ring-offset-2">
-                  <img src={currentUser.picture} alt="Profile" />
+                  <Image
+                    src={currentUser.picture}
+                    alt="Profile"
+                    width={40}
+                    height={40}
+                    className="rounded-full"
+                  />
                 </div>
               </div>
             )}

--- a/components/LoadingState.tsx
+++ b/components/LoadingState.tsx
@@ -1,9 +1,8 @@
 interface LoadingStateProps {
   isLoading: boolean;
-  isSigningIn: boolean;
 }
 
-export function LoadingState({ isLoading, isSigningIn }: LoadingStateProps) {
+export function LoadingState({ isLoading }: LoadingStateProps) {
   return (
     <div className="min-h-screen bg-gradient-to-br from-info/10 via-base-100 to-accent/10 flex items-center justify-center">
       <div className="card bg-gradient-to-br from-info/10 to-accent/10 shadow-xl border border-info/20">

--- a/components/TravelModeSelector.tsx
+++ b/components/TravelModeSelector.tsx
@@ -50,7 +50,7 @@ export function TravelModeSelector({
               />
             </svg>
             <span>
-              We'll show routes for driving 🚗, transit 🚌, walking 🚶, and
+              We&apos;ll show routes for driving 🚗, transit 🚌, walking 🚶, and
               biking 🚴 all at once!
             </span>
           </div>

--- a/components/ui/BottomNav.tsx
+++ b/components/ui/BottomNav.tsx
@@ -17,44 +17,6 @@ const HomeIcon = ({ className }: { className?: string }) => (
   </svg>
 );
 
-const ChartIcon = ({ className }: { className?: string }) => (
-  <svg
-    className={className}
-    fill="none"
-    stroke="currentColor"
-    viewBox="0 0 24 24"
-  >
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      strokeWidth={2}
-      d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
-    />
-  </svg>
-);
-
-const CogIcon = ({ className }: { className?: string }) => (
-  <svg
-    className={className}
-    fill="none"
-    stroke="currentColor"
-    viewBox="0 0 24 24"
-  >
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      strokeWidth={2}
-      d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
-    />
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      strokeWidth={2}
-      d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-    />
-  </svg>
-);
-
 const MapIcon = ({ className }: { className?: string }) => (
   <svg
     className={className}


### PR DESCRIPTION
## Summary
- Replace `any` usages with explicit interfaces in routes API
- Use Next.js Image component in header
- Clean up unused props and strings to satisfy lint

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_689ed52cf06c832aa7142ddffe4a9f3a